### PR TITLE
Use player-location attribute rather than player

### DIFF
--- a/book/part4/1-records.md
+++ b/book/part4/1-records.md
@@ -23,12 +23,11 @@ Let's create the over-arching record definition for our game state:
 (defrecord state
   objects
   places
-  player
+  player-location
   goals)
 ```
 
-We've just defined a record called ``state`` that has four fields: ``objects``, ``places``, ``player``, and ``goals``.
-
+We've just defined a record called ``state`` that has four fields: ``objects``, ``places``, ``player-location``, and ``goals``.
 
 ### Objects
 

--- a/book/part4/2-map.md
+++ b/book/part4/2-map.md
@@ -10,7 +10,7 @@ Now we can combine the data we have defined to finally make our world state!
 > (set state (make-state
                objects objects
                places (list living-room garden attic netherworld)
-               player 'living-room
+               player-location 'living-room
                goals goals))
 ```
 ```lisp

--- a/book/part5/1-location.md
+++ b/book/part5/1-location.md
@@ -5,7 +5,7 @@ The first command we'd want to have is a command that tells us about the locatio
 We can get there in stages by playing with our new game state and record functions. Getting the player location is super-easy:
 
 ```lisp
-> (state-player state)
+> (state-player-location state)
 living-room
 ```
 
@@ -13,7 +13,7 @@ What about a place's description? Well, that's buried a few more levels deep in 
 
 ```lisp
 > (fields-state)
-(objects places player goals)
+(objects places player-location goals)
 > (fields-object)
 (name location)
 > (fields-place)

--- a/book/part5/2-patts.md
+++ b/book/part5/2-patts.md
@@ -63,14 +63,14 @@ Let's create a function which uses ``lists:filter`` to only return the place tha
 
 ```lisp
 (defun get-here
-  (((match-state player player-loc places locs))
+  (((match-state player-location player-loc places locs))
     (car (lists:filter
            (lambda (loc)
              (here? player-loc loc))
            locs))))
 ```
 
-We used *pattern matching* again, but this time to do something a tiny bit clever: we used it to define the variables ``player-loc`` and ``locs``. In other words, with our pattern above, we said "When you get a ``state`` record coming through here, get its ``player`` field and assign it to the ``player-loc`` variable; also get its ``places`` field and assign it to the ``locs`` variable."
+We used *pattern matching* again, but this time to do something a tiny bit clever: we used it to define the variables ``player-loc`` and ``locs``. In other words, with our pattern above, we said "When you get a ``state`` record coming through here, get its ``player-location`` field and assign it to the ``player-loc`` variable; also get its ``places`` field and assign it to the ``locs`` variable."
 
 ![](../images/living_room.jpg)
 

--- a/book/part5/4-finding.md
+++ b/book/part5/4-finding.md
@@ -28,7 +28,7 @@ Remember that ``(state-objects state)`` returns all game objects. Let's use ``li
 
 ```lisp
 (defun whats-here?
-  (((match-state player player-loc objects objs))
+  (((match-state player-location player-loc objects objs))
     (lists:filter
       (lambda (obj)
         (item-there? player-loc obj))

--- a/book/part6/1-walking.md
+++ b/book/part6/1-walking.md
@@ -71,7 +71,7 @@ With these in place, we're ready to create our first action:
   (let ((exits (place-exits (get-here game-state))))
     (case (lists:member direction (get-valid-moves exits))
           ('true (good-move
-                   (set-state-player
+                   (set-state-player-location
                      game-state
                      (get-new-location direction exits))))
           ('false (bad-move game-state)))))

--- a/book/part6/3-interact.md
+++ b/book/part6/3-interact.md
@@ -43,7 +43,7 @@ That's all the helper functions we need; now for the main attraction:
 
 ```lisp
 (defun pickup-item
-  ((item-name (= (match-state player player-loc objects objs) game-state))
+  ((item-name (= (match-state player-location player-loc objects objs) game-state))
     (case (lists:member item-name (get-item-names game-state))
           ('true
             (set-state-objects

--- a/book/part6/4-cmplx.md
+++ b/book/part6/4-cmplx.md
@@ -72,7 +72,7 @@ The first of the goals we'll write code for is the welding of the chain to the b
 (defun weld-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (inv? 'chain game-state)
-           (== (state-player game-state) 'attic)))
+           (== (state-player-location game-state) 'attic)))
 ```
 
 As you can see, that function checks to make sure that all the necessary conditions are present for a successful welding.
@@ -138,7 +138,7 @@ Now let's create a command for dunking the chain and bucket in the well. We'll n
 (defun dunk-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (goal-met? 'weld-chain game-state)
-           (== (state-player game-state) 'garden)))
+           (== (state-player-location game-state) 'garden)))
 
 (defun dunk-not-ready ()
   (io:format "~nYou seem to be missing a key condition for dunking ...~n"))

--- a/book/part6/6-winact.md
+++ b/book/part6/6-winact.md
@@ -6,7 +6,7 @@ We're still missing one last special action: the one that will let us win the ga
 (defun splash-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (goal-met? 'dunk-bucket game-state)
-           (== (state-player game-state) 'living-room)))
+           (== (state-player-location game-state) 'living-room)))
 
 (defun splash-not-ready ()
   (io:format "~nYou seem to be missing a key condition for splashing ...~n"))
@@ -34,7 +34,7 @@ We're still missing one last special action: the one that will let us win the ga
       game-state)
     ('true
       (lost-msg)
-      (set-state-player game-state 'netherworld))))
+      (set-state-player-location game-state 'netherworld))))
 
 (defun already-splashed ()
   (io:format (++ "~nYou've already woken the wizard once. With a bucket full "

--- a/book/part7/4-server.md
+++ b/book/part7/4-server.md
@@ -18,7 +18,7 @@ create a game-state initializer like so:
   (make-state
     objects objects
     places (list living-room garden attic netherworld)
-    player 'living-room
+    player-location 'living-room
     goals goals))
 ```
 
@@ -49,7 +49,7 @@ Now we can create our state holder "server":
   (receive
     (`#(look)
       (display-scene state)
-      (case (state-player state)
+      (case (state-player-location state)
         ('netherworld (loop-server (hope-for-mercy state)))
         (_ (loop-server state))))
     (`#(exits)

--- a/code/game.lfe
+++ b/code/game.lfe
@@ -3,7 +3,7 @@
 (defrecord state
   objects
   places
-  player
+  player-location
   goals)
 
 (defrecord object
@@ -84,7 +84,7 @@
 (set state (make-state
              objects objects
              places (list living-room garden attic netherworld)
-             player 'living-room
+             player-location 'living-room
              goals goals))
 
 (defun here?
@@ -94,7 +94,7 @@
       'false))
 
 (defun get-here
-  (((match-state player player-loc places locs))
+  (((match-state player-location player-loc places locs))
     (car (lists:filter
            (lambda (loc)
              (here? player-loc loc))
@@ -121,7 +121,7 @@
       'false))
 
 (defun whats-here?
-  (((match-state player player-loc objects objs))
+  (((match-state player-location player-loc objects objs))
     (lists:filter
       (lambda (obj)
         (item-there? player-loc obj))
@@ -186,7 +186,7 @@
   (let ((exits (place-exits (get-here game-state))))
     (case (lists:member direction (get-valid-moves exits))
           ('true (good-move
-                   (set-state-player
+                   (set-state-player-location
                      game-state
                      (get-new-location direction exits))))
           ('false (bad-move game-state)))))
@@ -220,7 +220,7 @@
   (io:format "~nThat item is not here.~n"))
 
 (defun pickup-item
-  ((item-name (= (match-state player player-loc objects objs) game-state))
+  ((item-name (= (match-state player-location player-loc objects objs) game-state))
     (case (lists:member item-name (get-item-names game-state))
           ('true
             (set-state-objects
@@ -308,7 +308,7 @@
 (defun weld-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (inv? 'chain game-state)
-           (== (state-player game-state) 'attic)))
+           (== (state-player-location game-state) 'attic)))
 
 (defun weld-not-ready ()
   (io:format "~nYou seem to be missing a key condition for welding ...~n"))
@@ -342,7 +342,7 @@
 (defun dunk-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (goal-met? 'weld-chain game-state)
-           (== (state-player game-state) 'garden)))
+           (== (state-player-location game-state) 'garden)))
 
 (defun dunk-not-ready ()
   (io:format "~nYou seem to be missing a key condition for dunking ...~n"))
@@ -411,7 +411,7 @@
 (defun splash-ready? (game-state)
   (andalso (inv? 'bucket game-state)
            (goal-met? 'dunk-bucket game-state)
-           (== (state-player game-state) 'living-room)))
+           (== (state-player-location game-state) 'living-room)))
 
 (defun splash-not-ready ()
   (io:format "~nYou seem to be missing a key condition for splashing ...~n"))
@@ -439,7 +439,7 @@
       game-state)
     ('true
       (lost-msg)
-      (set-state-player game-state 'netherworld))))
+      (set-state-player-location game-state 'netherworld))))
 
 (defun already-splashed ()
   (io:format (++ "~nYou've already woken the wizard once. With a bucket full "
@@ -455,7 +455,7 @@
   (make-state
     objects objects
     places (list living-room garden attic netherworld)
-    player 'living-room
+    player-location 'living-room
     goals goals))
 
 (defun spell-of-mercy ()
@@ -483,7 +483,7 @@
   (receive
     (`#(look)
       (display-scene state)
-      (case (state-player state)
+      (case (state-player-location state)
         ('netherworld (loop-server (hope-for-mercy state)))
         (_ (loop-server state))))
     (`#(exits)

--- a/code/spels/include/records.lfe
+++ b/code/spels/include/records.lfe
@@ -1,7 +1,7 @@
 (defrecord state
   objects
   places
-  player
+  player-location
   goals)
 
 (defrecord object

--- a/code/spels/src/spels-env.lfe
+++ b/code/spels/src/spels-env.lfe
@@ -12,7 +12,7 @@
     'false))
 
 (defun get-here
-  (((match-state player player-loc places locs))
+  (((match-state player-location player-loc places locs))
     (car (lists:filter
            (lambda (loc)
              (here? player-loc loc))
@@ -25,7 +25,7 @@
       'false))
 
 (defun whats-here?
-  (((match-state player player-loc objects objs))
+  (((match-state player-location player-loc objects objs))
     (lists:filter
       (lambda (obj)
         (item-there? player-loc obj))

--- a/code/spels/src/spels-game.lfe
+++ b/code/spels/src/spels-game.lfe
@@ -50,7 +50,7 @@
 (defun handle_cast
   (('look state)
     (spels-io:display-scene state)
-    (case (state-player state)
+    (case (state-player-location state)
       ('netherworld
         `#(noreply ,(spels-io:hope-for-mercy state)))
       (_

--- a/code/spels/src/spels-inv.lfe
+++ b/code/spels/src/spels-inv.lfe
@@ -20,7 +20,7 @@
     (spels-env:whats-here? game-state)))
 
 (defun pickup-item
-  ((item-name (= (match-state player player-loc objects objs) game-state))
+  ((item-name (= (match-state player-location player-loc objects objs) game-state))
     (case (lists:member item-name (get-item-names game-state))
           ('true
             (set-state-objects

--- a/code/spels/src/spels-io.lfe
+++ b/code/spels/src/spels-io.lfe
@@ -126,7 +126,7 @@
       game-state)
     ('true
       (lost-msg)
-      (set-state-player game-state 'netherworld))))
+      (set-state-player-location game-state 'netherworld))))
 
 (defun already-splashed ()
   (io:format (++ "~nYou've already woken the wizard once. With a bucket full "

--- a/code/spels/src/spels-move.lfe
+++ b/code/spels/src/spels-move.lfe
@@ -26,7 +26,7 @@
   (let ((exits (place-exits (spels-env:get-here game-state))))
     (case (lists:member direction (get-valid-moves exits))
           ('true (spels-io:good-move
-                   (set-state-player
+                   (set-state-player-location
                      game-state
                      (get-new-location direction exits))))
           ('false (spels-io:bad-move game-state)))))
@@ -34,7 +34,7 @@
 (defun weld-ready? (game-state)
   (andalso (spels-inv:inv? 'bucket game-state)
            (spels-inv:inv? 'chain game-state)
-           (== (state-player game-state) 'attic)))
+           (== (state-player-location game-state) 'attic)))
 
 (defun weld-them
   (('chain 'bucket game-state)
@@ -55,12 +55,12 @@
 (defun dunk-ready? (game-state)
   (andalso (spels-inv:inv? 'bucket game-state)
            (spels-goals:goal-met? 'weld-chain game-state)
-           (== (state-player game-state) 'garden)))
+           (== (state-player-location game-state) 'garden)))
 
 (defun splash-ready? (game-state)
   (andalso (spels-inv:inv? 'bucket game-state)
            (spels-goals:goal-met? 'dunk-bucket game-state)
-           (== (state-player game-state) 'living-room)))
+           (== (state-player-location game-state) 'living-room)))
 
 (defmacro game-action (cmd sub obj goal-name)
   `(defun ,(spels-util:ccatoms `(do- ,cmd))

--- a/code/spels/src/spels-world.lfe
+++ b/code/spels/src/spels-world.lfe
@@ -61,5 +61,5 @@
   (make-state
     objects (objects)
     places (list (living-room) (garden) (attic) (netherworld))
-    player 'living-room
+    player-location 'living-room
     goals (goals)))


### PR DESCRIPTION
When I first saw the `state` record, I thought that the `player` attribute will hold a player object.  However, this attribute was meant to hold the player location.  I think it would be better to be more explicit about this attribute and rename it as `player-location`.
